### PR TITLE
docs(examples): improve README clarity

### DIFF
--- a/examples/caddy/README.md
+++ b/examples/caddy/README.md
@@ -1,5 +1,10 @@
 # Caddy Example
 
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
 ## Deploying
 
 Run `docker compose up` to start the following services defined in the
@@ -10,9 +15,15 @@ Run `docker compose up` to start the following services defined in the
 - `geoblock`: Geoblock service
 - `caddy`: Reverse proxy
 
-This example will use the configuration defined in the
-[`config.yaml`](./config.yaml) file. Caddy configuration is defined in the
-[`Caddyfile`](./Caddyfile) file.
+This example will use the configuration defined in the [`config.yaml`](./config.yaml)
+file. Caddy configuration is defined in the [`Caddyfile`](./Caddyfile) file.
+
+## How it works
+
+The rules in [`config.yaml`](./config.yaml) are configured to:
+
+- **Allow** requests where the host is `whoami-1.local`
+- **Deny** requests where the host is `whoami-2.local`
 
 ## Testing
 

--- a/examples/nginx/README.md
+++ b/examples/nginx/README.md
@@ -1,5 +1,10 @@
 # NGINX Example
 
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
 ## Deploying
 
 Run `docker compose up` to start the following services defined in the
@@ -10,9 +15,15 @@ Run `docker compose up` to start the following services defined in the
 - `geoblock`: Geoblock service
 - `nginx`: Reverse proxy
 
-This example will use the configuration defined in the
-[`config.yaml`](./config.yaml) file. NGINX configuration is defined in the
-[`nginx.conf`](./nginx.conf) file.
+This example will use the configuration defined in the [`config.yaml`](./config.yaml)
+file. NGINX configuration is defined in the [`nginx.conf`](./nginx.conf) file.
+
+## How it works
+
+The rules in [`config.yaml`](./config.yaml) are configured to:
+
+- **Allow** requests where the host is `whoami-1.local`
+- **Deny** requests where the host is `whoami-2.local`
 
 ## Testing
 

--- a/examples/traefik/README.md
+++ b/examples/traefik/README.md
@@ -1,5 +1,10 @@
 # Traefik Example
 
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
 ## Deploying
 
 Run `docker compose up` to start the following services defined in the
@@ -10,8 +15,15 @@ Run `docker compose up` to start the following services defined in the
 - `geoblock`: Geoblock service
 - `traefik`: Reverse proxy
 
-This example will use the configuration defined in the
-[`config.yaml`](./config.yaml) file.
+This example will use the configuration defined in the [`config.yaml`](./config.yaml)
+file.
+
+## How it works
+
+The rules in [`config.yaml`](./config.yaml) are configured to:
+
+- **Allow** requests where the host is `whoami-1.local`
+- **Deny** requests where the host is `whoami-2.local`
 
 ## Testing
 


### PR DESCRIPTION
## Summary
Improved the documentation in the `examples/` directory to provide better context for both developers and homelabbers.

- Added **Prerequisites** section (Docker and Docker Compose) to all example READMEs.
- Added a **How it works** section explaining that rule decisions are driven by the configuration in `config.yaml`.