### PR TITLE
chore(deps): update Go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Install golangci-lint

--- a/.github/workflows/nightly-update.yml
+++ b/.github/workflows/nightly-update.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Install golangci-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   timeout: 5m
-  go: "1.24"
+  go: "1.26"
 
 linters:
   enable:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/danroc/geoblock
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/go-playground/validator/v10 v10.30.3

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -2,7 +2,7 @@
 # E2E Tests
 # --------------------------------------------------------------------------------------
 
-FROM golang:1.26.0@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5
+FROM golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479
 
 RUN apt-get update && apt-get install -y jq
 


### PR DESCRIPTION
Update all Go version references to 1.26.4 to fix govulncheck false positives from x509 vulnerabilities that were flagged in 1.26.3.

Changes:
- `go.mod`: toolchain go1.26.3 → go1.26.4
- `tests/e2e/Dockerfile`: golang:1.26.0 → golang:1.26.4
- `.github/workflows/nightly-tests.yml`: go-version '1.26.3' → '1.26.4'
- `.github/workflows/nightly-update.yml`: go-version '1.26.3' → '1.26.4'
- `.golangci.yml`: go '1.24' → '1.26'